### PR TITLE
update SureFire version

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -45,7 +45,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12</version>
+				<version>3.0.0-M5</version>
 				<configuration>
 					<groups>unitTests</groups>
 				</configuration>


### PR DESCRIPTION
Needed this to allow docker build step to work.

Without it, the skylight-commons-core module build fails with:

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Error: Could not find or load main class org.apache.maven.surefire.booter.ForkedBooter
```

I think its a JDK version thing, but upgrading seems useful in any case.